### PR TITLE
added skill install a dynamic tooling for things

### DIFF
--- a/prompts/manifold_v0.1.0.md
+++ b/prompts/manifold_v0.1.0.md
@@ -129,6 +129,10 @@ For each tool below:
 - **Do NOT use this tool when**:
   - The user only wants to **view** existing notes (use `getNote` for a specific titled note, or summarize from prior tool results if available).
   - The user has not specified which thing the note belongs to; ask them to pick a thing first.
+  - The current Thing’s Skills (from `manifold_getThingSkills`) do **not** include `journal`. In this case:
+    - Explain that the Journal Skill is not installed for this Thing.
+    - Ask explicitly: _"Would you like to install the Journal Skill on this thing so we can add and read notes?"_
+    - If they say **yes**, explain that installation is a separate step that must be performed by the platform or an administrator, and that once Journal is installed, you will be able to use tools like `addNote` and `getNote`.
 
 9. Tool name: `getNote`
 
@@ -140,6 +144,17 @@ For each tool below:
   - The user is asking for a general history or list of all notes when note titles are unknown; explain that you can fetch notes by title, and help them narrow down or remember the title.
   - The user is trying to create or edit a note (use `addNote` for creation; editing is not supported unless a dedicated tool exists).
 
+10. Tool name: `manifold_installSkill`
+
+- **Purpose**: Install a logical Skill on a Thing by installing its backing KRL ruleset (currently supports `journal` and `safeandmine`).
+- **Use this tool when**:
+  - The user has explicitly confirmed that they want to install/enable a Skill on a specific Thing (for example, after you’ve explained that Journal is not installed and they say “Yes, install the Journal Skill on Backpack.”).
+  - You know both the Thing name and the Skill name (e.g., `journal`, `safeandmine`).
+- **Do NOT use this tool when**:
+  - The user is only exploring or asking conceptually about Skills without clearly authorizing an installation.
+  - The target Thing or Skill name is ambiguous; first clarify which Thing and which Skill they mean.
+  - The Skill name is not one of the supported values; in that case, explain which Skills you can install and ask them to choose.
+
 ## Tool usage policy
 
 - **Use tools only for supported intents**:
@@ -149,6 +164,11 @@ For each tool below:
   - Prefer the **most specific** tool that fits the user’s intent (e.g., use `manifold_change_thing_name` rather than `manifold_create_thing` + `manifold_remove_thing`).
   - Chain tools when a single user intent requires multiple steps (e.g., 'Create a laptop thing and add a note about the serial number').
   - If no listed tool fits the request, answer conversationally and explain that there is no tool support for that operation.
+  - When the user requests an action that requires a Skill the current Thing does not have (based on `manifold_getThingSkills`), do **not** say that the tool "does not exist":
+    - Instead, state that the Skill (for example, Journal) is not installed for that Thing.
+    - Briefly describe what the missing Skill would enable.
+    - Ask the user if they would like to install/enable that Skill.
+    - If they say **yes** and the Skill is supported by `manifold_installSkill`, call `manifold_installSkill` with the Thing name and Skill name, then refresh Skills with `manifold_getThingSkills` before attempting the original action again.
 - **Safety and confirmation**:
   - For destructive or state‑changing operations (`manifold_remove_thing`, `manifold_change_thing_name`, `updateOwnerInfo`, `safeandmine_newtag`, `addNote`), ensure the user’s intent is explicit and unambiguous; ask for confirmation when appropriate.
   - If a thing name or tag ID could correspond to multiple entities or is ambiguous, first help the user clarify which item they mean (often by using `manifold_getThings` or asking follow‑up questions).

--- a/src/backend/api-wrapper.js
+++ b/src/backend/api-wrapper.js
@@ -203,6 +203,105 @@ async function getNote(thingName, title) {
 }
 
 /**
+ * Install a logical Skill on a Thing by installing its backing KRL ruleset.
+ *
+ * Supported skills:
+ * - "journal"    -> io.picolabs.journal   (installed on the Thing's engine UI pico)
+ * - "safeandmine"-> io.picolabs.safeandmine (installed on the Thing pico itself)
+ *
+ * @param {string} thingName
+ * @param {string} skillName
+ * @returns {Promise<object>} Installation result metadata
+ */
+async function installSkillForThing(thingName, skillName) {
+  const SKILL_MAP = {
+    journal: {
+      rid: "io.picolabs.journal",
+      installOn: "engine", // use the engine/UI pico for this Thing
+    },
+    safeandmine: {
+      rid: "io.picolabs.safeandmine",
+      installOn: "thing", // use the Thing pico itself
+    },
+  };
+
+  const skillDef = SKILL_MAP[skillName];
+  if (!skillDef) {
+    throw new Error(
+      `Unknown Skill "${skillName}". Supported Skills are: ${Object.keys(SKILL_MAP).join(", ")}`,
+    );
+  }
+
+  const manifoldEci = await traverseHierarchy();
+  const engineEci = await getChildEciByName(manifoldEci, thingName);
+  if (!engineEci) {
+    throw new Error(`Thing "${thingName}" not found`);
+  }
+
+  const targetEci =
+    skillDef.installOn === "engine" ? engineEci : engineEci; // currently both use the child pico ECI
+
+  const alreadyInstalled = await picoHasRuleset(targetEci, skillDef.rid);
+  if (alreadyInstalled) {
+    return {
+      thingName,
+      skill: skillName,
+      rid: skillDef.rid,
+      installed: false,
+      message: "Skill already installed.",
+    };
+  }
+
+  const absolutePath = path.join(
+    __dirname,
+    `../../Manifold-api/${skillDef.rid}.krl`,
+  );
+  await installRuleset(targetEci, pathToFileURL(absolutePath).href);
+
+  // Give the ruleset a brief moment to initialize
+  await new Promise((r) => setTimeout(r, 2000));
+
+  return {
+    thingName,
+    skill: skillName,
+    rid: skillDef.rid,
+    installed: true,
+    message: "Skill installation triggered.",
+  };
+}
+
+/**
+ * Derive a Thing's installed Skills from its installed KRL rulesets.
+ *
+ * Skill mapping (current project conventions):
+ * - "manifold_core": always available for Manifold things
+ * - "safeandmine": provided by ruleset rid "io.picolabs.safeandmine"
+ * - "journal": provided by ruleset rid "io.picolabs.journal"
+ *
+ * @param {string} thingName
+ * @returns {Promise<string[]>} skill names
+ */
+async function getThingSkills(thingName) {
+  const skills = ["manifold_core"];
+  const manifoldEci = await traverseHierarchy();
+  const thingEci = await getChildEciByName(manifoldEci, thingName);
+  if (!thingEci) {
+    throw new Error(`Thing "${thingName}" not found`);
+  }
+
+  // Safe & Mine is expected to be installed on all things, but we still check for correctness.
+  if (await picoHasRuleset(thingEci, "io.picolabs.safeandmine")) {
+    skills.push("safeandmine");
+  }
+
+  if (await picoHasRuleset(thingEci, "io.picolabs.journal")) {
+    skills.push("journal");
+  }
+
+  return skills;
+}
+
+/**
  * Removes a Thing Pico by it's name.
  * @async
  * @function deleteThing
@@ -451,6 +550,8 @@ module.exports = {
   createThing,
   addNote,
   getNote,
+  installSkillForThing,
+  getThingSkills,
   setSquareTag,
   scanTag,
   updateOwnerInfo,

--- a/src/backend/krl-operation.js
+++ b/src/backend/krl-operation.js
@@ -205,11 +205,57 @@ async function getNote(thingName, title, id) {
   }
 }
 
+/**
+ * Derives which Skills are installed on a Thing by checking its installed rulesets.
+ * @param {string} thingName
+ * @param {string|number} id
+ * @returns {Promise<KrlResponse>} Standard envelope with { skills: string[] }
+ */
+async function manifold_getThingSkills(thingName, id) {
+  try {
+    const skills = await api.getThingSkills(thingName);
+    return okResponse({
+      id,
+      data: { thingName, skills },
+      meta: { kind: "query", domain: "manifold", type: "get_thing_skills" },
+    });
+  } catch (error) {
+    return errResponse({ id, code: "ENGINE_ERROR", message: error.message });
+  }
+}
+
+/**
+ * Installs a logical Skill on a Thing by installing its backing KRL ruleset.
+ * @param {string} thingName
+ * @param {string} skillName - e.g. "journal" or "safeandmine"
+ * @param {string|number} id
+ * @returns {Promise<KrlResponse>} Standard envelope with installation metadata
+ */
+async function manifold_installSkill(thingName, skillName, id) {
+  try {
+    const result = await api.installSkillForThing(thingName, skillName);
+    return okResponse({
+      id,
+      data: result,
+      meta: {
+        kind: "event",
+        domain: "manifold",
+        type: "install_skill",
+        httpStatus: 200,
+      },
+    });
+  } catch (error) {
+    return errResponse({ id, code: "ENGINE_ERROR", message: error.message });
+  }
+}
+
 module.exports = {
   manifold_getThings,
   manifold_create_thing,
   manifold_remove_thing,
   manifold_change_thing_name,
+  manifold_getThingSkills,
+  manifold_installSkill,
   safeandmine_newtag,
   scanTag,
   updateOwnerInfo,

--- a/src/backend/mcp-server/server.js
+++ b/src/backend/mcp-server/server.js
@@ -27,6 +27,8 @@ const {
   manifold_create_thing,
   manifold_remove_thing,
   manifold_change_thing_name,
+  manifold_getThingSkills,
+  manifold_installSkill,
   safeandmine_newtag,
   scanTag,
   updateOwnerInfo,
@@ -91,6 +93,35 @@ async function main() {
     },
     toolHandler(({ thingName, changedName, id }) =>
       manifold_change_thing_name(thingName, changedName, id),
+    ),
+  );
+
+  server.tool(
+    "manifold_getThingSkills",
+    "Derive which Skills are installed on a Thing by checking installed KRL rulesets.",
+    {
+      thingName: z
+        .string()
+        .describe("The name of the Thing pico to inspect for installed Skills"),
+      id: z.string().optional(),
+    },
+    toolHandler(({ thingName, id }) => manifold_getThingSkills(thingName, id)),
+  );
+
+  server.tool(
+    "manifold_installSkill",
+    "Install a logical Skill on a Thing by installing its backing KRL ruleset (e.g., journal, safeandmine).",
+    {
+      thingName: z
+        .string()
+        .describe("The name of the Thing pico to install the Skill on"),
+      skillName: z
+        .enum(["journal", "safeandmine"])
+        .describe("The logical Skill name to install (journal or safeandmine)"),
+      id: z.string().optional(),
+    },
+    toolHandler(({ thingName, skillName, id }) =>
+      manifold_installSkill(thingName, skillName, id),
     ),
   );
 

--- a/src/backend/mcp-server/tools.js
+++ b/src/backend/mcp-server/tools.js
@@ -85,10 +85,20 @@ const OUTPUT_SCHEMA = {
   },
 };
 
-function tool({ name, description, properties, required, outputDescription }) {
+function tool({
+  name,
+  description,
+  properties,
+  required,
+  outputDescription,
+  skill,
+}) {
   return {
     name,
     description,
+    // Logical grouping for dynamic tool exposure based on installed Skills
+    // e.g. "manifold_core", "safeandmine", "journal"
+    skill,
     inputSchema: {
       type: "object",
       additionalProperties: false,
@@ -105,6 +115,7 @@ function tool({ name, description, properties, required, outputDescription }) {
 // Manifold pico
 const manifold_getThings = tool({
   name: "manifold_getThings",
+  skill: "manifold_core",
   description:
     "List all digital things managed by Manifold. No arguments required.",
   properties: { id: TOOL_COMMON_PROPS.id },
@@ -115,6 +126,7 @@ const manifold_getThings = tool({
 
 const manifold_create_thing = tool({
   name: "manifold_create_thing",
+  skill: "manifold_core",
   description: "KRL event: manifold/create_thing (attrs: name)",
   properties: {
     ...TOOL_COMMON_PROPS,
@@ -127,6 +139,7 @@ const manifold_create_thing = tool({
 
 const manifold_remove_thing = tool({
   name: "manifold_remove_thing",
+  skill: "manifold_core",
   description: "Remove a thing pico from Manifold by its name.",
   properties: {
     id: TOOL_COMMON_PROPS.id,
@@ -142,6 +155,7 @@ const manifold_remove_thing = tool({
 
 const manifold_change_thing_name = tool({
   name: "manifold_change_thing_name",
+  skill: "manifold_core",
   description:
     "Rename a thing pico. Use the thing's current name and the new name.",
   properties: {
@@ -157,8 +171,48 @@ const manifold_change_thing_name = tool({
     "Event result (typically empty data object, check meta.httpStatus for success)",
 });
 
+const manifold_getThingSkills = tool({
+  name: "manifold_getThingSkills",
+  skill: "manifold_core",
+  description:
+    "Derive which Skills are installed on a Thing by checking installed KRL rulesets.",
+  properties: {
+    id: TOOL_COMMON_PROPS.id,
+    thingName: {
+      type: "string",
+      description: "The name of the Thing pico to inspect for installed Skills.",
+    },
+  },
+  required: ["thingName"],
+  outputDescription:
+    "Returns { thingName, skills: string[] } in data, where skills are logical groups like manifold_core, safeandmine, journal.",
+});
+
+const manifold_installSkill = tool({
+  name: "manifold_installSkill",
+  skill: "manifold_core",
+  description:
+    "Install a logical Skill on a Thing by installing its backing KRL ruleset (e.g., journal, safeandmine).",
+  properties: {
+    id: TOOL_COMMON_PROPS.id,
+    thingName: {
+      type: "string",
+      description: "The name of the Thing pico to install the Skill on.",
+    },
+    skillName: {
+      type: "string",
+      description:
+        "Logical Skill name to install (e.g., 'journal' or 'safeandmine').",
+    },
+  },
+  required: ["thingName", "skillName"],
+  outputDescription:
+    "Returns installation metadata, including which Skill and RID were installed for the Thing.",
+});
+
 const safeandmine_newtag = tool({
   name: "safeandmine_newtag",
+  skill: "safeandmine",
   description: "Assign a physical tag to a named Pico.",
   properties: {
     id: TOOL_COMMON_PROPS.id,
@@ -176,6 +230,7 @@ const safeandmine_newtag = tool({
 
 const scanTag = tool({
   name: "scanTag",
+  skill: "safeandmine",
   description: "Get owner info from a SquareTag scan.",
   properties: {
     id: TOOL_COMMON_PROPS.id,
@@ -192,6 +247,7 @@ const scanTag = tool({
 
 const updateOwnerInfo = tool({
   name: "updateOwnerInfo",
+  skill: "safeandmine",
   description: "Update owner info for a thing.",
   properties: {
     id: TOOL_COMMON_PROPS.id,
@@ -230,6 +286,7 @@ const updateOwnerInfo = tool({
 
 const addNote = tool({
   name: "addNote",
+  skill: "journal",
   description: "Add a note to a thing.",
   properties: {
     id: TOOL_COMMON_PROPS.id,
@@ -247,6 +304,7 @@ const addNote = tool({
 
 const getNote = tool({
   name: "getNote",
+  skill: "journal",
   description: "Get a note from a thing by title.",
   properties: {
     id: TOOL_COMMON_PROPS.id,
@@ -263,16 +321,32 @@ const getNote = tool({
   outputDescription: "Returns the content of the requested note.",
 });
 
+const ALL_TOOLS = [
+  manifold_getThings,
+  manifold_create_thing,
+  manifold_remove_thing,
+  manifold_change_thing_name,
+  manifold_getThingSkills,
+  manifold_installSkill,
+  safeandmine_newtag,
+  scanTag,
+  updateOwnerInfo,
+  addNote,
+  getNote,
+];
+
+// Index tools by Skill name for dynamic tool exposure:
+// { [skillName: string]: string[] } mapping Skill -> MCP tool names
+const SKILL_TOOL_INDEX = ALL_TOOLS.reduce((acc, t) => {
+  const skillName = t.skill || "manifold_core";
+  if (!acc[skillName]) {
+    acc[skillName] = [];
+  }
+  acc[skillName].push(t.name);
+  return acc;
+}, {});
+
 module.exports = {
-  tools: [
-    manifold_getThings,
-    manifold_create_thing,
-    manifold_remove_thing,
-    manifold_change_thing_name,
-    safeandmine_newtag,
-    scanTag,
-    updateOwnerInfo,
-    addNote,
-    getNote,
-  ],
+  tools: ALL_TOOLS,
+  SKILL_TOOL_INDEX,
 };

--- a/src/backend/skills-tool-bank.js
+++ b/src/backend/skills-tool-bank.js
@@ -1,0 +1,52 @@
+const { tools, SKILL_TOOL_INDEX } = require("./mcp-server/tools.js");
+const { getSkills } = require("./skills-registry-wrapper.js");
+
+/**
+ * Static Skill → tool mapping derived from local MCP tool definitions.
+ *
+ * Example shape:
+ * {
+ *   manifold_core: ["manifold_getThings", "manifold_create_thing", ...],
+ *   safeandmine:   ["safeandmine_newtag", "scanTag", "updateOwnerInfo"],
+ *   journal:       ["addNote", "getNote"]
+ * }
+ */
+function getStaticSkillToolBank() {
+  return { ...SKILL_TOOL_INDEX };
+}
+
+/**
+ * Return full MCP tool specs for a given list of Skill names.
+ * This is what an orchestrator / client can use to expose only tools
+ * for the Skills installed on a particular Thing.
+ *
+ * @param {string[]} skillNames
+ * @returns {object[]} Array of MCP tool descriptors (from src/backend/mcp-server/tools.js)
+ */
+function getToolsForSkills(skillNames = []) {
+  if (!Array.isArray(skillNames) || skillNames.length === 0) {
+    return [];
+  }
+
+  const skillSet = new Set(skillNames);
+  return tools.filter((t) => t.skill && skillSet.has(t.skill));
+}
+
+/**
+ * Optional helper to read the live Skills Registry pico and return
+ * whatever it currently knows about Skills. This does not yet drive
+ * MCP tool registration directly, but gives you a single place to
+ * look up Skills metadata if you want to sync or introspect.
+ *
+ * @returns {Promise<object[]>}
+ */
+async function getRegisteredSkills() {
+  return getSkills();
+}
+
+module.exports = {
+  getStaticSkillToolBank,
+  getToolsForSkills,
+  getRegisteredSkills,
+};
+

--- a/src/mcp-client/index.js
+++ b/src/mcp-client/index.js
@@ -16,6 +16,9 @@ const {
   getManifoldContext,
   updateManifoldContext,
 } = require("../backend/llm/llm-context.js");
+const {
+  getToolsForSkills,
+} = require("../backend/skills-tool-bank.js");
 
 class MCPClient extends EventEmitter {
   constructor() {
@@ -30,6 +33,15 @@ class MCPClient extends EventEmitter {
 
     this.mcp = new Client({ name: "mcp-web-client", version: "1.0.0" });
     this.tools = [];
+    /**
+     * Logical Skills currently available for the active Thing / context.
+     * By default, every Thing has the core Manifold skills and safeandmine.
+     * The "journal" Skill is optional and can be added when the Journal
+     * ruleset is installed on a Thing.
+     *
+     * Example values: ["manifold_core", "safeandmine", "journal"]
+     */
+    this.currentSkills = ["manifold_core", "safeandmine"];
     this.modelId = "us.anthropic.claude-3-5-sonnet-20241022-v2:0";
   }
 
@@ -243,6 +255,20 @@ class MCPClient extends EventEmitter {
                   .join("\n")
               : JSON.stringify(result);
 
+            // If we just derived Skills for a Thing, update currentSkills immediately
+            // so subsequent tool selection in this same query uses the correct subset.
+            if (name === "manifold_getThingSkills") {
+              try {
+                const parsed = JSON.parse(text);
+                const skills = parsed?.data?.skills;
+                if (Array.isArray(skills) && skills.length > 0) {
+                  this.setCurrentSkills(skills);
+                }
+              } catch (_) {
+                // Ignore parsing errors; tool result is still passed back to the LLM
+              }
+            }
+
             toolResults.push({
               toolResult: {
                 toolUseId,
@@ -285,13 +311,31 @@ class MCPClient extends EventEmitter {
 
   // Helper to keep processQuery clean
   prepareToolsForBedrock() {
-    return this.tools.map((tool) => ({
+    // Map current Skills to the subset of MCP tools that should be visible
+    const allowedToolsForSkills = getToolsForSkills(this.currentSkills);
+    const allowedNames = new Set(allowedToolsForSkills.map((t) => t.name));
+
+    return this.tools
+      .filter((tool) => allowedNames.has(tool.toolSpec.name))
+      .map((tool) => ({
       toolSpec: {
         name: tool.toolSpec.name,
         description: tool.toolSpec.description,
         inputSchema: { json: tool.toolSpec.inputSchema },
       },
     }));
+  }
+
+  /**
+   * Update the current Skills for the active Thing/context.
+   * This controls which MCP tools are advertised to the LLM.
+   *
+   * @param {string[]} skillNames - e.g. ["manifold_core", "safeandmine", "journal"]
+   */
+  setCurrentSkills(skillNames) {
+    if (Array.isArray(skillNames) && skillNames.length > 0) {
+      this.currentSkills = skillNames;
+    }
   }
 
   getSystemPrompt(version = "v0.1.0") {


### PR DESCRIPTION
This allows the MCP to have a tool to change the available list of tools based on the rulesets installed on the thing. Each MCP tool now has a skill section in their schema so that tool to change the list can know which tools go with which rulesets.
Add getThingSkills(thingName) in api-wrapper.js that checks installed RIDs on the Thing pico and maps them to Skills.
Implement installSkillForThing(thingName, skillName) in api-wrapper.js to install backing KRL rulesets for supported Skills if not already present.
Prompt updates to help instruct the LLM what to do when a tool is asked for and the skill is not installed.