### PR TITLE
Local and Prod Separation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# .env.example - Copy this to .env and fill in your keys
+AWS_REGION='us-east-2'
+AWS_ACCESS_KEY_ID='INSERT_YOUR_KEY_HERE'
+AWS_SECRET_ACCESS_KEY='INSERT_YOUR_SECRET_HERE'
+
+# Local Development Settings
+PICO_ENGINE_BASE_URL=http://localhost:3000
+VITE_API_URL=http://localhost:3001
+NODE_ENV=development
+PORT=3001

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,13 @@ jobs:
             cd ~/MCPforEXP
             git fetch origin main
             git reset --hard origin/main      # Discard local server changes (like .pico-engine)
+
+            echo "PICO_ENGINE_BASE_URL=${{ secrets.PICO_ENGINE_BASE_URL }}" > .env
+            echo "VITE_API_URL=${{ secrets.VITE_API_URL }}" >> .env
+            echo "AWS_REGION=us-east-2" >> .env
+            echo "NODE_ENV=production" >> .env
+            echo "PORT=3001" >> .env
+
             npm install
 
             # Restart only what changed to minimize downtime for your 30,000 users

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Link to [MCP Documentation](https://code.claude.com/docs/en/mcp)
 
 ```text
 ├── github/workflows
+├── docs
 ├── Manifold-api/           # .krl rules for the pico engine (MCP logic)
 ├── prompts/                # Prompt templates used by the MCP / LLM
 ├── scripts/                # Automation scripts (setup, teardown, testing)
@@ -58,9 +59,9 @@ Link to [MCP Documentation](https://code.claude.com/docs/en/mcp)
 │   └── frontend/
 ├── test/                   # Test suites
 │   ├── backend/
-│   │   ├── server/
-│   │   ├── llm/
-│   │   └── mcp/
+│   │   ├── mcp-server/
+│   │   ├── backend/
+│   │   └── mcp-client/
 │   └── frontend/
 ```
 
@@ -92,11 +93,7 @@ npm install
 
 ### Environment Variables
 
-Create a .env file with the following variables:
-
-AWS_REGION='us-east-2'
-PICO_ENGINE_BASE_URL=http://localhost:3000
-VITE_API_URL=http://manny.picolabs.io:3001
+Follow `.env.example` to set up your own .env file. You will need to supply your own values for the AWS variables, but should otherwise use the defaults.
 
 ### Setup
 
@@ -136,11 +133,8 @@ npm run test
 
 ## Running the Frontend
 
-To test or use our frontend component for interacting with the MCP client/LLM, you will need two terminals open and running.
+To test or use our frontend component for interacting with the MCP client/LLM, you will need three terminals open and running.
 
 1. Run `npm run dev` to open vite
 2. Run `npm run proxy` to connect to the mcp server
-
-Alternatively, open `http://18.217.240.202:3005/` in your browser to see the chatbot or `http://18.217.240.202:3000/` to see the associated pico-engine.
-
-NOTE: As it's currently configured, no matter which way the chatbot is opened, it will connect to the pico-engine instance running on the EC2 server. Any interactions you make with the pico-engine will be recorded and show up for any othe user. Multi-tenancy will be the next step.
+3. Run `pico-engine` to run the engine

--- a/src/backend/utility/http-utility.js
+++ b/src/backend/utility/http-utility.js
@@ -1,27 +1,22 @@
-require("dotenv").config();
+const path = require("path");
+require("dotenv").config({ path: path.resolve(__dirname, "../../.env") });
 
-async function checkENVVariable(variable, variableName) {
+function checkENVVariable(variable, variableName) {
   if (variable) {
     return variable;
-  } else {
-    console.error(
-      `CRITICAL: ${variableName} is ${typeof variable}. Check your .env file!`,
-    );
-    throw new Error(`The environment variable ${variableName} is missing.`);
   }
+  console.error(`CRITICAL: ${variableName} is missing. Check your .env file!`);
+  throw new Error(`The environment variable ${variableName} is missing.`);
 }
 
+// Get the URL once at the top level
+const PICO_BASE_URL = checkENVVariable(
+  process.env.PICO_ENGINE_BASE_URL,
+  "PICO_ENGINE_BASE_URL",
+);
+
 async function getFetchRequest(requestEndpoint) {
-  const baseURL = await checkENVVariable(
-    process.env.PICO_ENGINE_BASE_URL,
-    "PICO_ENGINE_BASE_URL",
-  );
-
-  // This automatically manages slashes safely
-  const requestURL = new URL(requestEndpoint, baseURL).href;
-
-  // console.error("getFetchRequest attempting:", requestURL);
-
+  const requestURL = new URL(requestEndpoint, PICO_BASE_URL).href;
   try {
     const response = await fetch(requestURL);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -33,26 +28,14 @@ async function getFetchRequest(requestEndpoint) {
 }
 
 async function postFetchRequest(requestEndpoint, requestBody) {
-  const baseURL = await checkENVVariable(
-    process.env.PICO_ENGINE_BASE_URL,
-    "PICO_ENGINE_BASE_URL",
-  );
-
-  const requestURL = new URL(requestEndpoint, baseURL).href;
-
+  const requestURL = new URL(requestEndpoint, PICO_BASE_URL).href;
   try {
     const response = await fetch(requestURL, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(requestBody),
     });
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
     return response;
   } catch (err) {
     console.error("Fetch Logic Failed: ", err.message);
@@ -60,7 +43,4 @@ async function postFetchRequest(requestEndpoint, requestBody) {
   }
 }
 
-module.exports = {
-  getFetchRequest,
-  postFetchRequest,
-};
+module.exports = { getFetchRequest, postFetchRequest };

--- a/src/frontend/vite.config.js
+++ b/src/frontend/vite.config.js
@@ -1,25 +1,31 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 3005, // Moves UI to 3005 to avoid the Pico-Engine on 3000
-    host: true, // Exposes the server to the public EC2 IP
-    strictPort: true, // Prevents Vite from accidentally picking a different port
-    allowedHosts: ["manny.picolabs.io", "engine.picolabs.io"],
-    proxy: {
-      // Keep your existing proxy settings for local communication on the server
-      "/api": {
-        target: "https://manny.picolabs.io",
-        changeOrigin: true,
-        secure: true,
-      },
-      "/socket.io": {
-        target: "https://manny.picolabs.io",
-        ws: true,
-        secure: true,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd() + "/../../", "VITE_");
+  const target = env.VITE_API_URL || "http://localhost:3001";
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 3005, // Moves UI to 3005 to avoid the Pico-Engine on 3000
+      host: true, // Exposes the server to the public EC2 IP
+      strictPort: true, // Prevents Vite from accidentally picking a different port
+      allowedHosts: ["manny.picolabs.io", "engine.picolabs.io"],
+      proxy: {
+        // Keep your existing proxy settings for local communication on the server
+        "/api": {
+          target: target,
+          changeOrigin: true,
+          secure: false,
+        },
+        "/socket.io": {
+          target: target,
+          ws: true,
+          changeOrigin: true,
+          secure: false,
+        },
       },
     },
-  },
+  };
 });

--- a/src/mcp-client/api-proxy.js
+++ b/src/mcp-client/api-proxy.js
@@ -1,15 +1,16 @@
+const path = require("path");
 require("dotenv").config({ path: path.join(__dirname, "../../.env") });
 const express = require("express");
 const http = require("http");
 const { Server } = require("socket.io");
 const cors = require("cors");
 const { MCPClient } = require("./index.js"); // Path to your refactored client
-const path = require("path");
 const app = express();
 const server = http.createServer(app);
 
 // Configure Socket.io with CORS for your EC2 setup
 const io = new Server(server, {
+  path: "/socket.io",
   cors: {
     origin: process.env.VITE_API_URL || "*",
     methods: ["GET", "POST"],

--- a/src/mcp-client/api-proxy.js
+++ b/src/mcp-client/api-proxy.js
@@ -1,23 +1,26 @@
+require("dotenv").config({ path: path.join(__dirname, "../../.env") });
 const express = require("express");
 const http = require("http");
 const { Server } = require("socket.io");
 const cors = require("cors");
 const { MCPClient } = require("./index.js"); // Path to your refactored client
 const path = require("path");
-
 const app = express();
 const server = http.createServer(app);
 
 // Configure Socket.io with CORS for your EC2 setup
 const io = new Server(server, {
   cors: {
-    origin: "*", // In production, replace with your EC2 public IP or Domain
+    origin: process.env.VITE_API_URL || "*",
     methods: ["GET", "POST"],
   },
 });
 
 app.use(cors());
 app.use(express.json());
+
+const PORT = process.env.PORT || 3001;
+const HOST = process.env.NODE_ENV === "production" ? "0.0.0.0" : "localhost";
 
 // 1. Initialize the "Brain"
 const client = new MCPClient();
@@ -67,8 +70,6 @@ app.post("/api/chat", async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 3001;
-
-server.listen(PORT, "0.0.0.0", () => {
-  console.error(`🚀 API Proxy & Socket server running on port ${PORT}`);
+server.listen(PORT, HOST, () => {
+  console.error(`🚀 API Proxy & Socket server running on ${HOST}:${PORT}`);
 });


### PR DESCRIPTION
I made some changes to the project structure so that it can once again be run locally for testing separate from the production instance. I modified parts of the workflow so that the variables are inserted dynamically so that it can still work on our production instance. 

To test this:
You will need to update your .env file. Follow the example in the new `.env.example` file I created. To generate your own AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID:
1. Go to the AWS Management Console and navigate to IAM.
2. Click on 'Users' within the left-hand menu and click on your email/account.
3. Navigate to the 'Security credentials' tab and scroll down to the section titled Access Keys. Click 'Create access key'.
4. Select 'Application running outside AWS'. Click 'Create access key' again.
5. CRITICAL: Copy both the Access key ID and Secret access key immediately to paste into your .env file, because once you navigate away from the page you won't be able to access them anymore.

Once your .env file is configured, you can open and run the following three terminals to test locally:
- npm run proxy
- npm run dev
- pico-engine